### PR TITLE
Upgrades to oxigraph 0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
       - run: pip install . && pip install -r requirements-dev.txt && pip install 'rdflib==6.3.0'
       - run: python -m unittest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -24,12 +24,12 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.6.7
     hooks:
       - id: ruff-format
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.11.2
     hooks:
       - id: mypy

--- a/oxrdflib/_converter.py
+++ b/oxrdflib/_converter.py
@@ -112,27 +112,19 @@ def from_ox(
     raise ValueError(f"Unexpected Oxigraph term: {term!r}")
 
 
-def rdflib_to_mime_type(rdflib_type: str) -> str:
+def guess_rdf_format(rdflib_type: str) -> ox.RdfFormat:
     """Convert an rdflib type to a MIME type."""
-    if rdflib_type in ("ttl", "turtle"):
-        return "text/turtle"
-    if rdflib_type in ("nt", "ntriples"):
-        return "application/n-triples"
-    if rdflib_type == "xml":
-        return "application/rdf+xml"
-    if rdflib_type == "trig":
-        return "application/trig"
-    if rdflib_type == "trix":
-        return "application/trix"
-    raise ValueError(f"Unsupported rdflib type: {rdflib_type}")
+    rdflib_type = ox_to_rdflib_type(rdflib_type)
+    rdf_format = (
+        ox.RdfFormat.from_media_type(rdflib_type)
+        or ox.RdfFormat.from_extension(rdflib_type)
+        or ox.RdfFormat.from_media_type(f"application/{rdflib_type}")
+    )
+    if rdf_format is None:
+        raise ValueError(f"Unsupported rdflib type: {rdflib_type}")
+    return rdf_format
 
 
 def ox_to_rdflib_type(ox_format: str) -> str:
     """Convert an Oxigraph format to a rdflib parser format."""
-    if ox_format in ("ox-turtle", "ox-ttl"):
-        return "turtle"
-    if ox_format in ("ox-nt", "ox-ntriples"):
-        return "nt"
-    if ox_format == "ox-xml":
-        return "xml"
-    raise ValueError(f"Unsupported Oxigraph type: {ox_format}")
+    return ox_format[len("ox-") :] if ox_format.startswith("ox-") else ox_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,21 @@ description = "rdflib stores based on pyoxigraph"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database :: Database Engines/Servers",
 ]
-dependencies = ["pyoxigraph~=0.3.14", "rdflib>=6.3,<8.0"]
+dependencies = ["pyoxigraph~=0.4.0", "rdflib>=6.3,<8.0"]
 dynamic = ["version"]
 license = { text = "BSD-3-Clause" }
 name = "oxrdflib"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 
 [project.entry-points."rdf.plugins.store"]


### PR DESCRIPTION
- Uses RdfFormat type
- Uses the loader "path" argument if possible to skip Python entirely