### PR TITLE
query: use new substitution feature

### DIFF
--- a/oxrdflib/store.py
+++ b/oxrdflib/store.py
@@ -142,15 +142,11 @@ class OxigraphStore(Store):
             raise NotImplementedError
         init_ns = dict(self._namespace_for_prefix, **initNs)
         query = "".join(f"PREFIX {prefix}: <{namespace}>\n" for prefix, namespace in init_ns.items()) + query
-        if initBindings:
-            query += "\nVALUES ( {} ) {{ ({}) }}".format(
-                " ".join(f"?{k}" for k in initBindings),
-                " ".join(v.n3() for v in initBindings.values()),
-            )
         result = self._inner.query(
             query,
             use_default_graph_as_union=queryGraph == "__UNION__",
             default_graph=(to_ox(queryGraph) if isinstance(queryGraph, Node) else None),
+            substitutions={ox.Variable(k): to_ox(v) for k, v in initBindings.items()},
         )
         if isinstance(result, ox.QueryBoolean):
             out = Result("ASK")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database :: Database Engines/Servers",
 ]
-dependencies = ["pyoxigraph~=0.4.2", "rdflib>=6.3,<8.0"]
+dependencies = ["pyoxigraph~=0.4.6", "rdflib>=6.3,<8.0"]
 dynamic = ["version"]
 license = { text = "BSD-3-Clause" }
 name = "oxrdflib"


### PR DESCRIPTION
Note that it relies on [SEP 0007](https://github.com/w3c/sparql-dev/blob/main/SEP/SEP-0007/sep-0007.md) semantic that differs from what rdflib does